### PR TITLE
Develop: remove local reference to tv4 library

### DIFF
--- a/cd_interface.json
+++ b/cd_interface.json
@@ -1,8 +1,8 @@
 {
-	"debug": false,
+	"debug": true,
 	"gpServiceUrl": {
-		"findProfile": "http://dev.services2.coastalresilience.org:6080/arcgis/rest/services/CoastalDefense/CD_Find_Closest_Profile/GPServer/Find_Closest_Profile",
-		"runWaveModel": "http://dev.services2.coastalresilience.org:6080/arcgis/rest/services/CoastalDefense/CD_Wave_Model/GPServer/Run_Wave_Model"
+		"findProfile": "http://dev.services2.coastalresilience.org/arcgis/rest/services/CoastalDefense/CD_Find_Closest_Profile/GPServer/Find_Closest_Profile",
+		"runWaveModel": "http://dev.services2.coastalresilience.org/arcgis/rest/services/CoastalDefense/CD_Wave_Model/GPServer/Run_Wave_Model"
 	},
 	"waveHeightPeriod": [2,4],
 	"waveType": [

--- a/main.js
+++ b/main.js
@@ -18,24 +18,11 @@ require({
 	        location: "//cdnjs.cloudflare.com/ajax/libs/underscore.js/1.4.4",
 	        main: "underscore-min"
 	    },
-			//         {
-			//             name: "extjs",
-			// location: location.pathname.replace(/\/[^/]+$/, "") + "plugins/coastal_defense/lib/ext-4.2.1-gpl",
-			//             main: "ext-all"
-			//         },
-        {
-            name: "tv4",
-            location: location.pathname.replace(/\/[^/]+$/, "") + "plugins/coastal_defense/lib",
-            main: "tv4.min"
-        },
         {
             name: "jquery_ui",
             location: "//ajax.googleapis.com/ajax/libs/jqueryui/1.10.1",
             main: "jquery-ui.min"
         }
-		
-		
-
     ]
 });
 


### PR DESCRIPTION
tv4 library reference is a remnant from the original plugin used as an initial template but is now included in the framework.
